### PR TITLE
retarget interop to net std 2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+Vulkan.Sandcastle/* linguist-documentation
+Vulkan.Sandcastle.Presentation/VulkanSandcastlePresentation/* linguist-documentation

--- a/Interop/Interop.csproj
+++ b/Interop/Interop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Interop</PackageId>
     <Authors>Tyler Young</Authors>
     <Company>Artilect</Company>


### PR DESCRIPTION
deal with string interning better on Utf8String interop class

add .gitattributes to identify documentation components